### PR TITLE
Update feedback data validation, and feedback sql query

### DIFF
--- a/src/controllers/feedbackControllers.js
+++ b/src/controllers/feedbackControllers.js
@@ -1,7 +1,7 @@
 const pool = require('../utilis/db');
 exports.getFeedback = async (req, res, next) => {
     try {
-        const feedbacks = (await pool.query('SELECT * FROM feedbacks')).rows
+        const feedbacks = (await pool.query('SELECT feedback, rating FROM feedbacks')).rows
         res.status(200).json({
             status: 'success',
             result: feedbacks

--- a/src/controllers/feedbackControllers.js
+++ b/src/controllers/feedbackControllers.js
@@ -12,7 +12,7 @@ exports.getFeedback = async (req, res, next) => {
 };
 
 exports.postFeedback = async (req, res, next) => {
-    const { id, name, email, feedback, rating } = req.body;
+    const {id, name, email, feedback, rating} = req.body;
 
     try {
         const postFeedback = await pool.query(`insert into feedbacks(id, name, email, feedback, rating) 

--- a/src/controllers/feedbackControllers.js
+++ b/src/controllers/feedbackControllers.js
@@ -1,39 +1,37 @@
 const pool = require('../utilis/db');
 exports.getFeedback = async (req, res, next) => {
-try {
-    const feedbacks = (await pool.query('SELECT * FROM feedbacks')).rows
-    res.status(200).json({
-        status: 'success',
-        result: feedbacks
-    })
-} catch (error) {
-    next(error)
-}
+    try {
+        const feedbacks = (await pool.query('SELECT * FROM feedbacks')).rows
+        res.status(200).json({
+            status: 'success',
+            result: feedbacks
+        })
+    } catch (error) {
+        next(error)
+    }
 };
 
 exports.postFeedback = async (req, res, next) => {
-    const {id, name, email, feedback, rating} = req.body;
+    const { id, name, email, feedback, rating } = req.body;
 
-try {
-const postFeedback = await pool.query(`insert into feedbacks(id, name, email, feedback, rating)
-    values($1, $2, $3, $4, $5)`,[id,name,email,feedback,rating]).rows;
+    try {
+        const postFeedback = await pool.query(`insert into feedbacks(id, name, email, feedback, rating) 
+            values($1, $2, $3, $4, $5)`, [id, name, email, feedback, rating])
 
-    if (!postFeedback) {
-        return res.status(400).json({
-            status: 'fail',
-            message: 'Feedback not posted'
-        })
-    };
+        if (postFeedback.rowCount < 1) {
+            return res.status(400).json({
+                status: 'fail',
+                message: 'Feedback not posted'
+            })
+        };
 
-    res.status(201).json({
-        status: 'success',
-        postFeedback
-    });
+        res.status(201).json({
+            status: 'success',
+            message: 'New feedback received'
+        });
 
-} catch (error) {
-
-    res.send(error)
-}
-next()
+    } catch (error) {
+        next(error)
+    }
 };
 

--- a/src/helpers/dataValidationJoi.js
+++ b/src/helpers/dataValidationJoi.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 
 const feedbackSchema = Joi.object({
+    id: Joi.string().min(1).required(),
     name: Joi.string().min(3).max(30).required(),
     email: Joi.string().email().required(),
     feedback: Joi.string().min(10).required(),
@@ -19,7 +20,5 @@ exports.validateFeedback = (req, res, next) => {
         });
     }
     req.body = value; // Update the request body with the validated value
-    console.log('** from validation file **',req.body)
-    
     next();
 };

--- a/src/helpers/dataValidationJoi.js
+++ b/src/helpers/dataValidationJoi.js
@@ -2,10 +2,10 @@ const Joi = require('joi');
 
 const feedbackSchema = Joi.object({
     id: Joi.string().min(1).required(),
-    name: Joi.string().min(3).max(30).required(),
+    name: Joi.string().min(3).max(40).required(),
     email: Joi.string().email().required(),
     feedback: Joi.string().min(10).required(),
-    rating: Joi.number().integer().min(1).max(10).required()
+    rating: Joi.string().min(1).max(10).required()
 });
 
 exports.validateFeedback = (req, res, next) => {

--- a/test/feedback.test.js
+++ b/test/feedback.test.js
@@ -1,30 +1,31 @@
+const { asyncWrapProviders } = require('async_hooks');
 const { getFeedback, postFeedback } = require('../src/controllers/feedbackControllers');
 const pool = require('../src/utilis/db');
+const { deserialize } = require('v8');
 jest.mock('../src/utilis/db', () => ({
     query: jest.fn(),
 }));
 
-const mockReq = {
+ const mockReq = {
+    };
 
-};
+    const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+    };
 
-const mockRes = {
-    status: jest.fn().mockReturnThis(),
-    json: jest.fn()
-};
-
-const mockNext = jest.fn();
-
-describe('feedback controller', () => {
-    it('should get all feedbacks', async () => {
+    const mockNext = jest.fn();
+describe('GET / feedbacks', () => {
+   
+    it('should get all feedbacks 200', async () => {
         // setup
-        const fackFeedback = [
+        const feedback = [
             {
                 id: 1,
                 name: 'Adam',
                 email: 'adam@hotmail.com',
                 feedback: 'great work keep working',
-                rate: 7.5
+                rate: 7
             },
             {
                 id: 2,
@@ -34,7 +35,7 @@ describe('feedback controller', () => {
                 rate: 8
             }
         ];
-        pool.query.mockResolvedValue({ rows: fackFeedback });
+        pool.query.mockResolvedValue({ rows: feedback });
         // call the actuall controler function
 
         await getFeedback(mockReq, mockRes, mockNext);
@@ -44,7 +45,68 @@ describe('feedback controller', () => {
         expect(mockRes.status).toHaveBeenCalledWith(200);
         expect(mockRes.json).toHaveBeenCalledWith({
             status: 'success',
-            result: fackFeedback
+            result: feedback
+        })
+    });
+});
+
+describe('POST / feedbacks 201', () => {
+
+
+    it('Should return 201 for posting new feedback', async () => {
+        //1. setup the request body
+        const newFeedback = {
+            id: 1,
+            name: 'Adam',
+            email: 'adam@hotmail.com',
+            feedback: 'great work keep working',
+            rating: 7
+        }
+        mockReq.body = newFeedback;
+        // 2. setup resolved query
+        await pool.query.mockResolvedValue({ rowCount: 1 });
+
+
+        // function to test
+
+        await postFeedback(mockReq, mockRes, mockNext);
+        // assert
+        expect(mockRes.status).toHaveBeenCalledWith(201);
+        expect(pool.query).toHaveBeenCalledWith(`insert into feedbacks(id, name, email, feedback, rating) 
+            values($1, $2, $3, $4, $5)`, [newFeedback.id, newFeedback.name, newFeedback.email, newFeedback.feedback, newFeedback.rating]);
+
+        expect(mockRes.json).toHaveBeenCalledWith({
+            status: 'success',
+            message: 'New feedback received'
+        })
+
+    });
+     it('Should return 400 Invalid Data', async () => {
+        
+        // setup
+        const invalidfeedback = {
+            id: 1,
+            name: 'Adam',
+            email: 'adam@hotmail.com',
+            feedback: 'great work keep working',
+            rating: 7 // this field violates data validation rule, number instead of string
+        };
+
+        mockReq.body = invalidfeedback;
+
+        pool.query.mockResolvedValue({ rowCount: 0 });
+
+        // call the controller function
+        await postFeedback(mockReq, mockRes, mockNext);
+        // assert
+        expect(mockRes.status).toHaveBeenCalledWith(400)
+        expect(pool.query).toHaveBeenCalledWith(`insert into feedbacks(id, name, email, feedback, rating) 
+            values($1, $2, $3, $4, $5)`, [invalidfeedback.id, invalidfeedback.name, invalidfeedback.email, invalidfeedback.feedback, invalidfeedback.rating]);
+        expect(mockRes.json).toHaveBeenCalledWith({
+            status: 'fail',
+            message: 'Feedback not posted'
         })
     })
-})
+
+});
+


### PR DESCRIPTION
This PR introduces two new implementations:-

1.  Update feedback data validation to allow the rating to be a string instead of a number, as the data is coming based on a JSON format.
2. To avoid providing unnecessary data, I updated the SQL query to get only the required data at the moment. 